### PR TITLE
fix: use version interpolation in install block

### DIFF
--- a/Formula/pgschema.rb
+++ b/Formula/pgschema.rb
@@ -7,7 +7,7 @@ class Pgschema < Formula
   license "Apache-2.0"
 
   def install
-    bin.install "pgschema-1.4.3-darwin-arm64" => "pgschema"
+    bin.install "pgschema-#{version}-darwin-arm64" => "pgschema"
   end
 
   test do


### PR DESCRIPTION
The bin.install line was hardcoded to a specific version, causing brew upgrade to fail with 'No such file or directory' error.

Using Ruby string interpolation #{version} ensures the install block automatically matches the downloaded binary filename for any version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)